### PR TITLE
Update Jupyter API version and fix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ out
 .gradle
 build
 **/.ipynb_checkpoints
-gradle.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,8 @@ plugins {
   signing
   `maven-publish`
   kotlin("jvm") version "1.6.0-RC"
-  kotlin("jupyter.api") version "0.10.3-31" // TODO: unresolved dependency after update?
+  id("com.google.devtools.ksp") version "1.6.0-RC-1.0.1-RC"
+  kotlin("jupyter.api") version "0.10.3-31"
   id("com.github.ben-manes.versions") version "0.39.0"
   id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.jupyter.add.scanner=true


### PR DESCRIPTION
There are two problems:
1. There was a recent change that broke the compatibility, I wrote about it in Kotlin Slack: https://kotlinlang.slack.com/archives/C4W52CFEZ/p1630318024011800
2. Problem of compatibility between KSP versions really exist, but I don't know how to solve it on Jupyter API plugin side, because we can't adjust the plugin version while applying another plugin in our plugin. So, if you use some unstable version of Kotlin, you can apply the corresponding version of KSP to the build. Alternatively, you can use the Jupyter integration without using scanner and annotations, this approach is described [here](https://github.com/Kotlin/kotlin-jupyter/blob/master/docs/libraries.md#adding-library-integration-avoiding-use-of-annotation-processor).